### PR TITLE
NWST-312: Cancel subscription when max retries reached

### DIFF
--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -1980,14 +1980,11 @@ class PaymentIntent(StripeObject):
         return obj
 
     @classmethod
-    def _api_retry(cls, id, payment_method=None, **kwargs):
+    def _api_retry(cls, id, **kwargs):
         """ api method specifically for retrying the payment intent
         """
         if kwargs:
             raise UserError(400, 'Unexpected ' + ', '.join(kwargs.keys()))
-
-        if payment_method is not None:
-            raise UserError(500, 'Not implemented')
 
         try:
             assert type(id) is str and id.startswith('pi_')

--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -1222,7 +1222,7 @@ class Invoice(StripeObject):
     def next_payment_attempt(self):
         # configurable envvar MAX_PAYMENT_FAILURE_RETRIES
         # simulating the customizable retry schedule on Stripe Dashboard
-        max_retries = os.getenv("MAX_PAYMENT_FAILURE_RETRIES", 3)
+        max_retries = int(os.getenv("MAX_PAYMENT_FAILURE_RETRIES", 3))
         if self.status in ('draft', 'open'):
             # we need to + 1 to include the first payment failure too
             # same as Stripe, next_payment_attempt would become null when there are no more retries
@@ -1275,7 +1275,7 @@ class Invoice(StripeObject):
         # updating attributes here for simplicity
         # TODO: implement invoice.updated handling and emit webhook event
         self.attempt_count += 1
-        if self.attempt_count >= os.getenv("MAX_PAYMENT_FAILURE_RETRIES", 3) + 1:
+        if self.attempt_count >= int(os.getenv("MAX_PAYMENT_FAILURE_RETRIES", 3)) + 1:
             self.auto_advance = False
             self.closed = True
         if self.status == 'void':
@@ -1293,7 +1293,7 @@ class Invoice(StripeObject):
         # updating attributes here for simplicity
         # TODO: implement invoice.updated handling and emit webhook event
         self.attempt_count += 1
-        if self.attempt_count >= os.getenv("MAX_PAYMENT_FAILURE_RETRIES", 3) + 1:
+        if self.attempt_count >= int(os.getenv("MAX_PAYMENT_FAILURE_RETRIES", 3)) + 1:
             self.auto_advance = False
             self.closed = True
         if self.status == 'void':
@@ -2985,9 +2985,8 @@ class Subscription(StripeObject):
                 charge.payment_method).type == 'sepa_debit'):
                 return Subscription._api_delete(self.id)
 
-        max_retries = os.getenv("MAX_PAYMENT_FAILURE_RETRIES", 3)
-        # delete the subscription when max_retries is reached
-        if invoice.attempt_count >= max_retries + 1:
+        # delete the subscription when max retries is reached
+        if invoice.attempt_count >= int(os.getenv("MAX_PAYMENT_FAILURE_RETRIES", 3)) + 1:
             return Subscription._api_delete(self.id)
 
         # no need to emit the updated event when the status remains past_due


### PR DESCRIPTION
Changes:
1. extended Subscription._on_recurring_payment_failure to cancel the subscription when max retries reached
2. can configure max number of retries via env var MAX_PAYMENT_FAILURE_RETRIES
3. add "payment_intent.payment_failed" webhook event
4. update invoice attributes(attempt_count, auto_advance, closed) during payment and retry failures
5. added Invoice._api_retry_invoice and PaymentIntent._api_retry for the payment retry scenario